### PR TITLE
Using a phx-hook, don't love the eval

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -9,6 +9,14 @@ import css from "../css/app.css"
 //
 // Import dependencies
 //
+
+const Hooks = {};
+Hooks.Tick = {
+  mounted() {
+    eval(this.el.innerHTML);
+  }
+}
+
 import "phoenix_html"
 
 // Import local files
@@ -20,5 +28,5 @@ import {Socket} from "phoenix"
 import LiveSocket from "phoenix_live_view"
 
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");
-let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}});
+let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}, hooks: Hooks});
 liveSocket.connect()

--- a/lib/phoenix_liveview_web/controllers/counter_live.ex
+++ b/lib/phoenix_liveview_web/controllers/counter_live.ex
@@ -4,7 +4,7 @@ defmodule PhoenixLiveviewWeb.CounterLive do
 
   def render(assigns) do
     ~L"""
-    <script id="run_<%= @tick %>">
+    <script id="run_<%= @tick %>" phx-hook="Tick">
       console.log("I was updated <%= @tick %> times")
     </script>
     Current count: <%= @counter %>


### PR DESCRIPTION

Looks like the better way to control client side work is through `phx-hook` with some information on it available here:
https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#module-js-interop-and-client--controlled-dom

I kept the example as _identical_ as possible, but I think the better route would be to move the code you are trying to run into JS, instead of blindly `eval` ing that script.